### PR TITLE
embeddingsRoutes fix, usage counts added to dataToEmbeddingResponse

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ app.use(
 );
 app.use('/v1/models', modelsRoutes);
 app.use('/v1/chat', chatRoutes);
-app.use('/v1/embeddings', embeddingsRoutes);
+app.use(/^\/v1(?:\/.+)?\/embeddings$/, embeddingsRoutes);
 app.get('/', (req, res) =>
 	res.type('text/plain').send(`
 ################################################################################

--- a/routes/embeddingsRoutes.js
+++ b/routes/embeddingsRoutes.js
@@ -77,8 +77,6 @@ router.post('/', async (req, res) => {
 		: req.body.input;
 	const scriptArgs = ['-m', modelPath, '-p', input.replace(/"/g, '\\"')];
 	const promptTokens = Math.ceil(input.length / 4);
-	let completionTokens = 0;
-
 
 	!!global.childProcess && global.childProcess.kill('SIGINT'); // kill previous childprocess
 	global.childProcess = spawn(scriptPath, scriptArgs);
@@ -96,7 +94,6 @@ router.post('/', async (req, res) => {
 			const onData = (chunk) => {
 				const data = stripAnsiCodes(decoder.decode(chunk));
 				outputString += data;
-				completionTokens++;
 			};
 
 			const onClose = () => {
@@ -109,12 +106,10 @@ router.post('/', async (req, res) => {
 				res.status(200).json(dataToEmbeddingResponse(
 					output,
 					promptTokens,
-					completionTokens
 				));
 				console.log(dataToEmbeddingResponse(
 					output,
 					promptTokens,
-					completionTokens
 				))
 				controller.close();
 				console.log('Embedding Request DONE');

--- a/utils.js
+++ b/utils.js
@@ -60,7 +60,11 @@ export const dataToResponse = (
 	};
 };
 
-export const dataToEmbeddingResponse = (output) => {
+export const dataToEmbeddingResponse = (
+	output,
+	promptTokens,
+	completionTokens
+) => {
 	return {
 		object: 'list',
 		data: [
@@ -71,6 +75,11 @@ export const dataToEmbeddingResponse = (output) => {
 			},
 		],
 		embeddingSize: output.length,
+		usage: {
+			prompt_tokens: promptTokens,
+			completion_tokens: completionTokens,
+			total_tokens: promptTokens + completionTokens,
+		},
 	};
 };
 

--- a/utils.js
+++ b/utils.js
@@ -63,7 +63,6 @@ export const dataToResponse = (
 export const dataToEmbeddingResponse = (
 	output,
 	promptTokens,
-	completionTokens
 ) => {
 	return {
 		object: 'list',
@@ -77,8 +76,7 @@ export const dataToEmbeddingResponse = (
 		embeddingSize: output.length,
 		usage: {
 			prompt_tokens: promptTokens,
-			completion_tokens: completionTokens,
-			total_tokens: promptTokens + completionTokens,
+			total_tokens: promptTokens,
 		},
 	};
 };


### PR DESCRIPTION
- index.js changed app.use('/v1/embeddings', embeddingsRoutes); to app.use(/^\/v1(?:\/.+)?\/embeddings$/, embeddingsRoutes); to process embeddings like: https://api.openai.com/v1/engines/text-embedding-ada-002/embeddings

- utils.js added usage - prompt_tokens / completion_tokens / total_tokens to the dataToEmbeddingResponse.

- embeddingsRoutes.js added promptTokens and completionTokens count logic.