### PR TITLE
Update WizardLM.js

### DIFF
--- a/ChatEngine/WizardLM.js
+++ b/ChatEngine/WizardLM.js
@@ -13,6 +13,10 @@ export class WizardLM extends ChatEngine {
 		});
 		this.stopPrompts = [
 			...this.stopPrompts,
+			'USER:',
+			'\nUSER',
+			'SYSTEM:',
+			'\nSYSTEM',
 			'</s>',
 			'\n</s>',
 			'\n</s',


### PR DESCRIPTION
Since the rolemap changes in WizardLM to "USER" from "user", so that they are Uppercase now, the stop prompts are missed when checked (they include "user", not "USER"). Either just add these additional stop prompts here, or perhaps force lowercase when checking in chatRoute, my fix seemed less obtrusive a fix.

Btw, do not overwrite original stop prompts like lower case "user" because I have seen this happen in WizardLM at least for me as well.